### PR TITLE
Add support for openbsd, test on openbsd 6.8

### DIFF
--- a/proc_info/openbsd_proc_info.c
+++ b/proc_info/openbsd_proc_info.c
@@ -1,0 +1,48 @@
+#include <fcntl.h>
+#include <kvm.h>
+#include <sys/sysctl.h>
+
+
+#include <unistd.h>
+#include <stdio.h>
+#include <time.h>
+
+int main(int argc,char** args) {
+	kvm_t* kd;
+
+	// Get a handle to libkvm interface
+	kd = kvm_open(NULL, NULL, NULL, KVM_NO_FILES, "error: ");
+
+	pid_t pid;
+	pid = getpid();
+
+	struct kinfo_proc * kp;
+	int p_count;
+
+	// Get the kinfo_proc2 for this process by its pid
+	kp = kvm_getprocs(kd, KERN_PROC_PID, pid, sizeof(struct kinfo_proc), &p_count);
+
+	printf("got %i kinfo_proc2 for pid %i\n", p_count, pid);
+
+
+	// /usr/include/sys/sysctl.h details the kinfo_proc2 struct
+	time_t proc_start_time;
+	proc_start_time = kp->p_ustart_sec;
+	kvm_close(kd);
+
+
+	printf("sleeping for 15 seconds\n");
+	sleep(15);
+	printf("Process started at      %s\n", ctime(&proc_start_time));
+
+	time_t current_time;
+	current_time = time(NULL);
+	printf("Current time after nap  %s\n", ctime(&current_time));
+
+		
+
+
+	return 0;
+}
+
+


### PR DESCRIPTION
Add file with OpenBSD support #3   . Tested under OpenBSD 6.8

Not current Makefile doesn't work on OpenBSD, using default (bsd) make.